### PR TITLE
docs: add SPEC kernel and companions for youtube-organizer

### DIFF
--- a/_bmad-output/specs/spec-youtube-organizer/.memlog.md
+++ b/_bmad-output/specs/spec-youtube-organizer/.memlog.md
@@ -1,0 +1,77 @@
+---
+topic: YouTube Organizer — a personal curation library that moves saved YouTube videos into an intent-organized app and kills the doomscroll
+updated: 2026-07-24T12:51
+---
+
+- (event) Create operation. Interactive run, Alexis, English. resolve_customization.py failed (needs Python 3.11+ for tomllib); read customize.toml directly per the SKILL.md fallback. No bmad-spec override files exist, so all defaults apply.
+- (note) persistent_facts points at {project-root}/project-context.md, which does not exist; the real file is _bmad-output/project-context.md and was loaded instead. Worth fixing the default or the file location.
+- (direction) Alexis chose to distill the full planning chain: PRD + DESIGN.md + EXPERIENCE.md + ARCHITECTURE-SPINE.md + WORK-SPLIT.md.
+- (direction) Alexis chose the PRD as an absorbed source, not an adopted companion: every load-bearing PRD claim lands in SPEC.md or a spec-authored companion, and downstream stops reading the PRD.
+- (decision) Slug is youtube-organizer, inherited from the existing artifact slugs (prd-youtube-organizer-2026-07-20, ux-youtube-organizer-2026-07-23, architecture-youtube-organizer-2026-07-24). Spec folder: _bmad-output/specs/spec-youtube-organizer/.
+- (decision) Capability IDs map 1:1 onto the PRD FR ids (CAP-n = FR-n, 19 of them). ARCHITECTURE-SPINE.md binds: and WORK-SPLIT.md epics both reference FR ids, so a 1:1 mapping keeps the adopted companions wired to the kernel instead of orphaning their traceability.
+- (decision) Adopted companions (bmad-spec references, never edits): ARCHITECTURE-SPINE.md, WORK-SPLIT.md, DESIGN.md, EXPERIENCE.md, project-context.md, Docs/FRONTEND-STACK.md, Docs/CI-AND-GITHUB-GATES.md.
+- (decision) Spec-authored companions: glossary.md (the PRD section 3 vocabulary, a multi-item catalog that every downstream reader needs) and phasing.md (the Phase 1 / Phase 2 / out-of-scope FR matrix plus the FR-8 pull-forward trigger).
+- (decision) Diagrams are not duplicated into a spec-authored companion. Every diagram in the corpus already lives in ARCHITECTURE-SPINE.md and WORK-SPLIT.md, which are adopted companions, so the kernel cites them and holds prose only.
+- (decision) Precedence recorded in the kernel: ARCHITECTURE-SPINE.md wins over project-context.md and over Docs/ on any conflict, because it was decided for this repo rather than mirrored from Accountr. Both Docs/ files already carry superseding banners for AD-2 and AD-3, so no unamended divergence remains.
+- (capability) CAP-1 (FR-1) Authenticate with Google/YouTube at read AND write scope; read-only consent degrades to a first-class read-only mode rather than a broken app.
+- (capability) CAP-2 (FR-2) Designate any normal YouTube playlist as the _Inbox capture target, persisted in the database per user, changeable from the UI, with a create-one-for-me fallback.
+- (capability) CAP-3 (FR-3) Import selected pre-existing YouTube playlists structure-preserving, deduped, with a completion summary. Phase 2.
+- (capability) CAP-4 (FR-4) Optionally delete migrated playlists from YouTube, per-deletion confirmation, only after a confirmed successful import. Phase 2.
+- (capability) CAP-5 (FR-5) Import the _Inbox into the Library as Uncategorized with full local metadata, three distinct dates, and three-way dedupe across active, soft-deleted and tombstoned videos.
+- (capability) CAP-6 (FR-6) Crash-safe auto-clear of the _Inbox on YouTube: persist and verify locally before removing upstream; undrained removals become retried orphans, never silent failures.
+- (capability) CAP-7 (FR-7) Fast bulk categorization in Uncategorized: multi-select, bulk tag, bulk freshness, bulk discard, within the triage bound.
+- (capability) CAP-8 (FR-8) Assistive categorization suggestions that never auto-apply. Phase 2, with a pull-forward trigger.
+- (capability) CAP-9 (FR-9) Manage tags: create, apply by delta, rename, remove; merge is Phase 2.
+- (capability) CAP-10 (FR-10) Build and manage ordered hand-built playlists; removing a video from a playlist drops only that membership. Phase 2.
+- (capability) CAP-11 (FR-11) Delete a video from the Library, guarded by a counted confirmation and recoverable via Trash, purging to a tombstone; app-side only, never touches YouTube.
+- (capability) CAP-12 (FR-12) Channel and length captured automatically as filterable facets.
+- (capability) CAP-13 (FR-13) Browse by any AND-combination of facets: tags, channel, length range, freshness, watched, and a from-to date range over any of the three dates. Date filtering is Phase 2.
+- (capability) CAP-14 (FR-14) Text search across title, description, channel name and tags, globally or scoped to the current view.
+- (capability) CAP-15 (FR-15) Embedded in-app playback with no recommendation feed or autoplay-next, plus an open-in-YouTube escape hatch.
+- (capability) CAP-16 (FR-16) Auto-mark watched on contiguous coverage past a configurable threshold; watched videos stay in place and are manually togglable.
+- (capability) CAP-17 (FR-17) Mark a video evergreen or perishable with a watch-by window, settable in bulk. Phase 2.
+- (capability) CAP-18 (FR-18) Surface expired perishables for bulk watch-or-discard review. Phase 2.
+- (capability) CAP-19 (FR-19) Detect and flag videos YouTube no longer serves, surface them for review, and never show a broken player. Phase 2.
+- (constraint) Triage bound: filing a single video takes at most 2 interactions, and applying a tag or attribute to a multi-selection is a single action. Load-bearing for SM-C2 — if triage costs more than the doomscroll it replaced, the product has failed.
+- (constraint) Incremental by design: the app must never require Uncategorized to be emptied. A partially-triaged library is first-class; browse, search and playback all work fully over whatever is already organized.
+- (constraint) Anti-doomscroll subtraction: no infinite scroll, no autoplay-next (including inside hand-built playlists), no right rail at any breakpoint, no recommendation or subscription surfaces, no badge count on Uncategorized, and never a single-column full-width feed on phones.
+- (constraint) Persist and verify before mutating the source. Order is fetch, persist locally, verify, then enqueue the upstream clear. A video that failed import or verification is never enqueued for removal.
+- (constraint) Every outbound YouTube mutation is committed as a database intent in the same transaction as the app state and executed later by a separate drain — never issued inline (AD-6).
+- (constraint) Watch Later is inaccessible via the YouTube Data API, so a user-designated _Inbox playlist is the only viable capture on-ramp. Decided, not open (PRD R1).
+- (constraint) Background and lock-screen playback are impossible for an embedded player. Accepted as a platform limitation; open-in-YouTube covers the background-audio case (PRD R2).
+- (constraint) The embedded player renders YouTube recommendations on its own end screen and rel=0 no longer suppresses this. Alexis considered end-card interception and declined it — an accepted, documented leak in the subtraction contract.
+- (constraint) All import, clear and delete work must stay inside the single-user YouTube Data API daily quota. Exhaustion is detected reactively from the quotaExceeded error, never predicted; the run is stamped, committed work stays committed, and the banner persists until acknowledged.
+- (constraint) The app is the sole home of video metadata after import, so local durability is non-negotiable: a make backup target and a verified restore path exist from the first data-model story, and the irreversible upstream operation (playlist deletion) is gated on a recent successful backup (AD-20).
+- (constraint) Desktop and mobile web are both first-class from day one — keyboard-accelerated triage on desktop, touch triage on mobile, neither a degraded copy. No native app in any phase.
+- (constraint) WCAG 2.2 AA across both surfaces and both color modes. No state conveyed by color alone; focus differs from selection by style, not width; single-key shortcuts ship with disable, remap and focus scoping.
+- (constraint) Single user, one account, no sharing — yet every user-owned entity still carries a user FK and every query filters on it, so the assumption is never load-bearing in the schema (AD-18).
+- (constraint) Phase 1 targets localhost only. Dev defaults (DEBUG on, hardcoded SECRET_KEY, empty ALLOWED_HOSTS) are accepted only because nothing is deployed; the full production envelope must land as its own work before any non-local exposure (AD-17).
+- (constraint) Phase 1 sync is user-triggered only — a Sync now action and the idempotent manage.py sync_inbox command. No scheduler, cron, worker daemon or broker (AD-9).
+- (constraint) The shipped frontend/src prototype is not precedent. New surfaces are built to Docs/FRONTEND-STACK.md and the UX spines; legacy files are deleted when the surface replacing them lands (AD-13).
+- (constraint) ARCHITECTURE-SPINE.md AD-1 through AD-20 are binding and win over project-context.md and Docs/ on any conflict. Downstream cites AD ids in PRs.
+- (constraint) Never add AI or bot attribution to any artifact in this repository — commits, PR titles and bodies, comments, code comments, changelogs, generated docs. No exceptions.
+- (decision) Non-goals lifted whole from PRD section 5 and 6.3: not a YouTube playlist manager, not multi-user, not a quota dashboard, not a downloader or offline archive, not an algorithmic recommender, no native mobile app, no in-app background playback.
+- (decision) Success signal is behavioral, not commercial: Alexis opens the app rather than YouTube to decide what to watch, the _Inbox is cleared roughly weekly, and he is still using it a month in. Counter-metrics SM-C1 (library size is not a win) and SM-C2 (triage effort must stay below the doomscroll it replaced) are carried into the kernel because they constrain design, not just measurement.
+- (decision) PRD Open Question 5 (_Inbox disappears) is resolved by EXPERIENCE.md State Patterns — banner plus a choose-another action — and is dropped from open questions.
+- (decision) PRD Open Question 6 (quota exhaustion mid-triage) is resolved by AD-8 — stamp the run, commit what is done, resume from the same point, banner persists until acknowledged — and is dropped.
+- (decision) PRD Open Question 7 (watched accuracy vs scrubbing) is resolved by AD-15 — contiguous covered duration, never furthest position — and is dropped.
+- (decision) PRD assumption on the FR-18 freshness cue is resolved by DESIGN.md — a status badge that renders nothing until a perishable window has actually expired — and is dropped.
+- (decision) PRD assumption that FR-8 suggestions are deferrable is now a phasing decision with an explicit trigger, recorded in phasing.md rather than left as an assumption.
+- (assumption) Tag merge (FR-9) is wanted to fight tag drift that only appears after months of tagging. Unconfirmed.
+- (assumption) The watched threshold defaults to about 90 percent. AD-15 fixes the measurement, not the number; the value is a Settings option.
+- (assumption) Availability (FR-19) is checked opportunistically at play time and during sync rather than by background polling. Cadence unset, pending real quota measurements.
+- (assumption) Single-user volume of about 100 videos per week fits the default 10k-unit YouTube Data API daily quota. Unvalidated, and it underwrites the entire weekly loop.
+- (assumption) The inherited frontend pin block in Docs/FRONTEND-STACK.md records another project (Accountr) pins at a past date. The one pin checked is already behind its LTS line, so the rest are treated as suspect and must be re-verified before the first frontend PR.
+- (question) What is the real YouTube API unit cost of a 100-video import-plus-clear cycle? This validates or breaks the quota assumption that the weekly loop rests on.
+- (question) Longer term, do watched videos clutter browse enough to need an archive-watched sweep? Deferred until real use; AD-5 keeps Watched derived so a later lens costs nothing.
+- (question) If FR-8 suggestions are pulled forward, what powers them — channel and title heuristics, or the user own past tagging patterns? No architecture is committed until the triage pressure valve is actually needed.
+- (question) How should a partial migration import fail and retry (FR-3, Phase 2)? Definable once API cost and limits are known.
+- (question) Removing the last tag or playlist membership from a video silently drops it back into Uncategorized, since AD-5 makes that state derived. Confirm the silent fallback is wanted, or whether an explicit keep-untagged state is needed — the latter would require a new AD.
+- (question) How long is the Trash retention window? A product setting, not an architectural invariant; any value works against AD-10.
+- (event) Memlog seeded from the full planning chain; deriving SPEC.md, glossary.md and phasing.md next.
+- (event) Self-validate pass 1 (coherence, Spec Law 1-6 and 8): PASS after four fixes. Rule 2 breaches repaired in CAP-9, CAP-13 and CAP-14, where success criteria prescribed the mechanism (no whole-array tags PATCH, one list endpoint, same endpoint for search) instead of the outcome; each now states the guarantee and cites the AD that implements it. All 19 capabilities carry intent and success; 18 constraints each rule something out; 7 non-goals; the success signal is demonstrable (under ten seconds to a decision, weekly inbox clear, still in use after a month).
+- (decision) Added a token-handling constraint the corpus implied but no single line stated: write scope means a leaked token can destroy source data, so env-driven secrets and the AD-14 cookie/CORS invariants are non-negotiable. Preserves PRD section 8 security-inherited and R3.
+- (decision) Added SM-4 (library trends lean, perishables pruned) to the success signal; pass 2 found it collapsed into the SM-C1 counter-signal, which inverted it.
+- (assumption) PRD R5 carried forward: the product rests on YouTube continued API and embed-player policies, and a change could force another on-ramp or playback rework. Accepted risk for a personal tool. Pass 2 caught this as an unlanded source claim.
+- (event) Self-validate pass 2 (preservation): PASS. Every load-bearing PRD claim landed. Sections 1 and 2.1 to Why; section 3 to glossary.md; FR-1 to FR-19 with all consequences to CAP-1 to CAP-19; section 5 and 6.3 to Non-goals; section 6 to phasing.md; sections 7 and 8 to Success signal and Constraints; section 9 to Assumptions; section 10 R1 to R5 to Constraints and Assumptions; section 11 to Open Questions minus the three the spine and UX resolved. The four user journeys are preserved by adoption — EXPERIENCE.md Key Flows carries them under the same names and is a companion. Wrapper-only content dropped: PRD section 0 (document purpose, downstream-consumer note, the BACKLOG.md replacement history) and the inline ASSUMPTION and NOTE FOR PM tag apparatus, whose content was lifted into Assumptions and phasing.md.
+- (event) Spec finalized: SPEC.md, glossary.md, phasing.md derived. 19 capabilities, 2 spec-authored companions, 7 adopted companions, 6 assumptions, 6 open questions.

--- a/_bmad-output/specs/spec-youtube-organizer/SPEC.md
+++ b/_bmad-output/specs/spec-youtube-organizer/SPEC.md
@@ -1,0 +1,167 @@
+---
+id: SPEC-youtube-organizer
+companions:
+  - glossary.md
+  - phasing.md
+  - ../../planning-artifacts/architecture/architecture-youtube-organizer-2026-07-24/ARCHITECTURE-SPINE.md
+  - ../../planning-artifacts/architecture/architecture-youtube-organizer-2026-07-24/WORK-SPLIT.md
+  - ../../planning-artifacts/ux-designs/ux-youtube-organizer-2026-07-23/DESIGN.md
+  - ../../planning-artifacts/ux-designs/ux-youtube-organizer-2026-07-23/EXPERIENCE.md
+  - ../../project-context.md
+  - ../../../Docs/FRONTEND-STACK.md
+  - ../../../Docs/CI-AND-GITHUB-GATES.md
+sources:
+  - ../../planning-artifacts/prds/prd-youtube-organizer-2026-07-20/prd.md
+---
+
+> **Canonical contract.** This SPEC and the files in `companions:` are the complete, preservation-validated contract for what to build, test, and validate. Source documents listed in frontmatter are for traceability only — consult them only if you need narrative rationale or prose color this contract intentionally omits.
+
+# YouTube Organizer
+
+**Capability IDs map 1:1 onto the PRD's FR ids** — `CAP-n` *is* `FR-n`. `ARCHITECTURE-SPINE.md`'s `binds:` list and `WORK-SPLIT.md`'s epics both address FR ids; the mapping is what keeps them wired to this kernel.
+
+**Precedence.** `ARCHITECTURE-SPINE.md` (invariants `AD-1`–`AD-20`) wins over `project-context.md` and over `Docs/` on any conflict — it was decided for this repo rather than mirrored from another project. `DESIGN.md` and `EXPERIENCE.md` own the visual and behavioral spines respectively and win over the mockups they reference.
+
+## Why
+
+**A pain to solve, for exactly one person.** Alexis saves a lot of interesting YouTube videos and they pile up. YouTube's tools for managing that pile are slow and shallow, so finding *the right thing to watch* means scrolling an endless chronological list — and that scrolling **is** the doomscroll. He ends up watching whatever sits near the top of Watch Later instead of what he actually wants.
+
+YouTube Organizer flips this. It is a **personal curation library** where YouTube is only a *source*, not the home of organization. Videos are captured into the app, organized by intent — tags, channel, length, hand-built playlists — and pruned so the library stays lean. When he wants to watch, he browses by mood and context ("I have an hour for guitar," "a history podcast while I cook") and finds it in seconds, then watches inside the app, away from the recommendation machinery. Secondarily it is a **vision to realize**: his own tool, engineered properly — real architecture, tests, CI — for an audience of one.
+
+## Capabilities
+
+Phase assignment for every capability lives in `phasing.md`. Vocabulary (Library, Video, `_Inbox`, Uncategorized, Facet, Tag, Playlist, Freshness, Watched, Availability) is defined in `glossary.md` and is used with those exact meanings throughout.
+
+- **CAP-1** *(= FR-1)*
+  - **intent:** Alexis signs in with Google and grants the app read **and write** access to his YouTube playlists.
+  - **success:** After consent the app can list playlists, read playlist items, and remove or modify items on his behalf. If only read scope is granted, CAP-6 and CAP-4 are disabled with a clear persistent notice and everything else still works.
+
+- **CAP-2** *(= FR-2)*
+  - **intent:** Alexis designates one of his normal YouTube playlists as the `_Inbox` capture target.
+  - **success:** The app lists his playlists for selection; the choice is persisted in the database per user (never an env var or a hardcoded value), is changeable from the UI with effect on the next import, and the app can create an `_Inbox` playlist for him if he has no suitable one.
+
+- **CAP-3** *(= FR-3)*
+  - **intent:** Alexis imports selected pre-existing YouTube playlists, replicating their structure in the app.
+  - **success:** All his playlists are listed for selection; importing one creates an app Playlist of the same name with membership preserved; completion shows a summary of playlists, videos and failures; re-running creates no duplicate Videos or Playlists.
+
+- **CAP-4** *(= FR-4)*
+  - **intent:** After a successful import, Alexis can delete the migrated playlists from YouTube.
+  - **success:** Deletion is never automatic, each one is individually confirmed, declining leaves the YouTube playlist untouched, and a deletion only proceeds after its import is confirmed successful. Gated on a recent successful backup (see Constraints).
+
+- **CAP-5** *(= FR-5)*
+  - **intent:** Alexis imports new videos from the `_Inbox` into the Library, where — carrying no Tags and no Playlist membership — they appear as Uncategorized.
+  - **success:** Each imported Video stores title, description, channel, thumbnail, duration and YouTube ID/URL locally, plus three distinct dates (imported, source-added, published). Dedupe tests active, soft-deleted **and** tombstoned videos by YouTube ID, so a previously deleted video is never resurrected from a still-populated `_Inbox`.
+
+- **CAP-6** *(= FR-6)*
+  - **intent:** After a Video is durably held locally, the app removes it from the `_Inbox` on YouTube.
+  - **success:** Removal happens only after persist-and-verify, so a crash between steps never destroys the only copy. A video that failed import or verification is never removed. A video imported but not cleared is tracked as a pending-clear orphan, retried on the next sync, and never skipped as a duplicate. Removal failures surface in the UI.
+
+- **CAP-7** *(= FR-7)*
+  - **intent:** Alexis multi-selects Videos in Uncategorized and applies Tags, sets Freshness, or discards, in bulk.
+  - **success:** One action applies one or more Tags to a whole selection; Freshness is settable the same way; discard is available on the selection. Filing a single Video takes ≤2 interactions. Desktop keyboard triage and mobile touch triage are both first-class. Partially-triaged state is normal and blocks nothing.
+
+- **CAP-8** *(= FR-8)*
+  - **intent:** The app suggests Tags or attributes for a Video, which Alexis confirms or ignores.
+  - **success:** No suggestion is ever applied without an explicit user action.
+
+- **CAP-9** *(= FR-9)*
+  - **intent:** Alexis creates, applies, renames, removes and merges Tags.
+  - **success:** A Video carries multiple Tags. Renaming updates every application. Concurrent tag edits **compose rather than overwrite** — a single-video edit never destroys tags a bulk apply just added. Two tags that differ only in case or surrounding whitespace are the same tag, and applying one returns the existing one rather than splitting it across two rows. Merge is the only operation that collapses two tags into one. (Mechanism: `AD-19`.)
+
+- **CAP-10** *(= FR-10)*
+  - **intent:** Alexis builds ordered Playlists, adds and removes Videos, and reorders them.
+  - **success:** A Playlist has a user-defined order; a Video can belong to several. Removing a Video from a Playlist drops **only that membership** — the Video stays in the Library and in its other Playlists.
+
+- **CAP-11** *(= FR-11)*
+  - **intent:** Alexis deletes a Video from the Library — the only action that removes a Video from the app.
+  - **success:** Deletion removes it from active views and from every Playlist and Tag, is available singly and in bulk, and bulk delete requires an explicit confirmation stating the count. Deleted Videos go to a recoverable Trash for a retention window, then purge to a tombstone. Deletion is app-side only and never touches YouTube.
+
+- **CAP-12** *(= FR-12)*
+  - **intent:** Channel and Length are captured automatically and usable as filters.
+  - **success:** Every imported Video has its source channel and duration populated, and can be filtered by channel and by length range.
+
+- **CAP-13** *(= FR-13)*
+  - **intent:** Alexis browses the Library filtered by any combination of Tags, Channel, Length range, Freshness, Watched state and a date range.
+  - **success:** Filters combine with AND (e.g. `tag=guitar` AND length ≤ 60 min AND watched=no) and results reflect the active set. Date filtering is a from–to window with either bound optional, selectable against imported, source-added or published date, which is what makes age-based pruning ("everything I saved before 2023") possible. **Every browse surface answers a combined query identically** — no two surfaces may disagree about what a given filter combination means. (Mechanism: `AD-4`.)
+
+- **CAP-14** *(= FR-14)*
+  - **intent:** Alexis searches the Library by title, description, channel name and tags.
+  - **success:** A query matches any of those four fields, runs globally, and can be scoped to the current view or an open Playlist. Search composes with the CAP-13 facets rather than being a separate mode, and stays correct after bulk tagging — the highest-volume operation in the product — so a Video is always findable by the tags it actually carries. (Mechanism: `AD-11`.)
+
+- **CAP-15** *(= FR-15)*
+  - **intent:** Alexis plays a Video in an embedded in-app player, or opens it on YouTube.
+  - **success:** The embedded player exposes no recommendation feed and no autoplay-next inside the app; an open-in-YouTube action hands off to YouTube for the background-audio case.
+
+- **CAP-16** *(= FR-16)*
+  - **intent:** A Video is marked Watched once Alexis has actually watched enough of it.
+  - **success:** The client measures **contiguous covered duration**, never furthest position reached, so seeking to the end does not mark a video watched. Crossing the configurable threshold sets Watched and shows the badge; the Video stays exactly where it was; Watched is also manually togglable. Playback position is not persisted — there is no resume feature.
+
+- **CAP-17** *(= FR-17)*
+  - **intent:** Alexis marks a Video Evergreen or Perishable with a watch-by window.
+  - **success:** Freshness defaults to Evergreen, and is settable in bulk via CAP-7.
+
+- **CAP-18** *(= FR-18)*
+  - **intent:** The app proactively surfaces Perishable Videos past their window for bulk review.
+  - **success:** Expired Videos are collected into a review surface from which Alexis can bulk discard or keep.
+
+- **CAP-19** *(= FR-19)*
+  - **intent:** The app detects Videos YouTube no longer serves and flags them, so a sole-home Library does not silently fill with dead links.
+  - **success:** A Video that is deleted, private, region-blocked or removed is marked Unavailable and visibly flagged; Unavailable Videos are filterable and reviewable alongside expired perishables; attempting to play one shows a clear message with open-in-YouTube and delete actions, never a broken player.
+
+## Constraints
+
+- **Triage bound.** Filing a single Video takes **≤2 interactions**; applying a Tag or attribute to a multi-selection is **a single action**. No per-video modal gauntlet. If triage costs more than the doomscroll it replaced, the product has failed — this is the binding form of counter-metric SM-C2.
+- **Incremental by design.** The app must never require Uncategorized to be emptied. A partially-triaged Library is a first-class state: browse, search and playback work fully over whatever is already organized, so skipping triage for weeks degrades findability of *new* saves only. No "mark as done" step exists.
+- **Anti-doomscroll subtraction.** Banned everywhere: infinite scroll (pagination or explicit load-more only), autoplay-next including inside hand-built playlists, a right rail at any breakpoint (absent, not collapsed), recommendation/subscription/Shorts/Home surfaces, a badge count on Uncategorized, and a single-column full-width feed on phones (two columns minimum — that shape *is* the doomscroll). Also banned: hover-only affordances, modal stacks deeper than one level, and suppressible destructive confirmations.
+- **Persist and verify before mutating the source.** The order is fetch → persist locally → verify → enqueue the upstream clear. Dedupe suppresses re-import, never re-clear. (`AD-7`)
+- **Every outbound YouTube mutation goes through a transactional outbox.** App state and the intent to mutate YouTube commit in the same database transaction; a separate drain is the only caller of the gateway's write methods. Nothing issues a YouTube write inline. (`AD-6`)
+- **Watch Later is inaccessible** via the YouTube Data API, so a user-designated `_Inbox` playlist is the only viable capture on-ramp. Decided, not open — it costs a one-time habit change.
+- **Background/lock-screen playback is impossible in-app.** The embed pauses on tab-blur and lock; continuous audio is Premium-gated and blocked for embeds. Accepted; open-in-YouTube covers the case. Stated in Settings as fact, never surfaced as an error.
+- **The embed leaks recommendations on its own end screen** and `rel=0` has not suppressed that since 2018. End-card interception was considered and **declined**; the leak stands as an accepted limitation at the moment of peak doomscroll vulnerability, and is worth revisiting if it pulls him back into scrolling.
+- **YouTube API quota bounds everything.** All import/clear/delete work must fit the single-user daily quota; writes are batched and minimized. Exhaustion is detected **reactively** from the API's `quotaExceeded` error, never predicted — stamp the run, commit what is already done, resume from the same point next run, and keep the banner up until it is explicitly acknowledged.
+- **The app is the sole home of the library after import**, so durability is non-negotiable: a `make backup` target and a verified restore path exist from the first data-model story, the Postgres volume is named and never destroyed by any routine command, and **CAP-4 — the only irreversible upstream operation — is offered only when a successful backup exists within a defined recency window.** Import and inbox-clear are not gated; gating the weekly loop would break it.
+- **Both surfaces are first-class from day one.** Desktop is keyboard-accelerated, mobile is touch; neither is a degraded copy. No native app in any phase.
+- **WCAG 2.2 AA across both surfaces and both color modes.** No state conveyed by color alone (selection is outline + checkmark, status is scrim + badge, active nav is tint + edge bar). Focus differs from selection by *style* — dashed vs solid — not by width. Single-key shortcuts ship with a disable toggle, remapping, and focus scoping. Target size ≥24×24. Single-user does not lower this bar: a personal tool is used for years, tired, one-handed, at 1am.
+- **Single user, but never schema-deep.** No sharing, collaboration or public surface in any phase — yet every user-owned entity carries a user FK, every query filters on it, and uniqueness is scoped per user, so the assumption is never load-bearing in the data model.
+- **Phase 1 targets localhost only.** The dev `docker-compose.yml` is the only environment; `DEBUG=True`, a hardcoded `SECRET_KEY` and empty `ALLOWED_HOSTS` are accepted **only** because nothing is deployed. No story may assume a production environment exists, and the full production envelope must land as its own work before any non-local exposure.
+- **Phase 1 sync is user-triggered only** — a "Sync now" action and the idempotent `manage.py sync_inbox`. No scheduler, cron, worker daemon or broker.
+- **Write scope raises the stakes on token handling.** Adding YouTube write to the OAuth scope set means a leaked token can now *destroy* the user's source data, not just read it. Google and database credentials come from the environment and are never hardcoded or committed; the auth invariants (JWT in an HttpOnly cookie, credentialed CORS against a single origin, `SameSite=None; Secure`) are not relaxed, because the cross-port OAuth flow depends on them.
+- **The shipped `frontend/src` prototype is not precedent.** New surfaces are built to `Docs/FRONTEND-STACK.md` and the UX spines; legacy files are deleted when the surface replacing them lands. No long-lived hybrid, no in-place migration.
+- **`AD-1`–`AD-20` in `ARCHITECTURE-SPINE.md` are binding**, win over `project-context.md` and `Docs/` on conflict, and are cited by id in PRs.
+- **Never add AI or bot attribution to any artifact** in this repository — commit messages, PR titles and bodies, issue and review comments, code comments, changelogs, generated docs. No exceptions and no case-by-case judgement about whether a surface counts.
+
+## Non-goals
+
+- **Not a YouTube playlist manager.** No creating or managing arbitrary playlists *on YouTube* beyond reading and clearing `_Inbox` and the optional migration cleanup. Organization lives in the app.
+- **Not multi-user.** No sharing, collaboration, accounts for others, or public surfaces.
+- **Not a YouTube-quota dashboard.** Quota is an internal engineering constraint, not a user-facing feature.
+- **Not a downloader or offline archive.** No video files are downloaded; playback is always through YouTube's player.
+- **Not an algorithmic recommender.** The app never auto-decides what to watch and never auto-categorizes; suggestions are assistive and always confirmed.
+- **No native mobile app**, in any phase — reconsidered only if background playback ever becomes a hard requirement, which it is not.
+- **No in-app background or lock-screen playback.** Covered by open-in-YouTube.
+
+## Success signal
+
+Alexis opens *this app*, not YouTube's feed, to decide what to watch in the large majority of sessions; his `_Inbox` is cleared roughly weekly and stays near-empty; and a month in, he has not abandoned the tool. Concretely: on a random Tuesday he goes from opening the app to knowing what he is watching in **under ten seconds**, without scrolling past anything, because the set he drilled into was finite and *ended*.
+
+Secondarily, the library trends toward "stuff I'll actually watch" — perishables get pruned rather than accumulating.
+
+Two counter-signals bound this and are as binding as the goals: **library size is not a success metric** — a bigger library is worse, not better, if it is unwatched; and **if keeping the library organized costs more time than the doomscroll it replaced, the product has failed** (the designed response is to pull CAP-8 forward — see `phasing.md`).
+
+## Assumptions
+
+- Tag merge (CAP-9) is wanted to fight the tag drift that only appears after months of tagging.
+- The Watched threshold defaults to ~90%. The *measurement* is fixed (contiguous coverage); the *number* is a Settings value.
+- Availability (CAP-19) is checked opportunistically at play time and during sync rather than by background polling. The cadence is unset pending real quota measurements.
+- Single-user volume (~100 videos/week) fits the default 10k-unit daily YouTube Data API quota. Unvalidated — and it underwrites the entire weekly loop.
+- The product rests on YouTube's continued API and embed-player policies. A future policy change — as already happened with Watch Later — could force another capture on-ramp or playback rework. Accepted risk for a personal tool; recorded so it is not a surprise.
+- The frontend pin block inherited from `Docs/FRONTEND-STACK.md` records another project's versions at a past date. The one pin that was checked is already behind its LTS line, so the rest are treated as suspect and must be re-verified before the first frontend PR — amending the doc, not the code, where a pin moves.
+
+## Open Questions
+
+- What is the real YouTube API unit cost of a 100-video import-plus-clear cycle? This validates or breaks the quota assumption the weekly loop rests on.
+- Longer term, do Watched videos clutter browse enough to warrant an archive-watched sweep? (Deferred until real use; Watched is derived, so a later lens costs nothing.)
+- If CAP-8 suggestions are pulled forward, what powers them — channel/title heuristics, or Alexis's own past tagging patterns?
+- How should a partial migration import (CAP-3) fail and retry? Definable once API cost and limits are known.
+- Removing the last Tag or Playlist membership from a Video silently drops it back into Uncategorized, because that state is derived. Is the silent fallback wanted, or is an explicit "keep, leave untagged" state needed? The latter would require materialising a stored state and a new `AD`.
+- How long is the Trash retention window? A product setting, not an architectural invariant — any value works.

--- a/_bmad-output/specs/spec-youtube-organizer/glossary.md
+++ b/_bmad-output/specs/spec-youtube-organizer/glossary.md
@@ -1,0 +1,26 @@
+# Glossary — YouTube Organizer
+
+Companion to `SPEC.md`. These terms are used with exactly these meanings in the kernel, in
+`ARCHITECTURE-SPINE.md`, and in `EXPERIENCE.md`. Where a term names a *derived* state, that
+is load-bearing: derived states are computed by query at read time and never stored (`AD-5`).
+
+| Term | Definition |
+|---|---|
+| **Library** | The canonical set of **all** captured Videos. A Video always lives in the Library, independent of any Tag or Playlist — those are optional overlays and never determine whether a Video exists. Deleting a Video from the Library removes it entirely. |
+| **Video** | A single YouTube video captured into the app. The app stores its **own copy** of the metadata (title, description, channel, thumbnail, duration, published date, YouTube URL/ID) plus app-side timestamps, so it survives removal from any YouTube playlist. Belongs to zero-or-more Playlists; carries Facets. |
+| **Source (YouTube)** | YouTube, used only as the origin of videos. Never the home of organization. |
+| **`_Inbox`** | One normal YouTube playlist the user designates as the capture target, replacing Watch Later (which the Data API cannot reach). The app reads it and removes imported items from it. The designation is persisted per user in the database — never an environment variable. |
+| **Migration** | The one-time first-run import of pre-existing YouTube playlists, replicating their structure in the app. |
+| **Uncategorized** | A **derived view** of the Library: Videos with no Tags and no Playlist membership. Self-clearing — a Video leaves the moment it gets its first Tag or Playlist membership. A *state*, not a container; an Uncategorized Video still lives in the Library. |
+| **Facet** | A structured attribute used for filtered browsing: **Tag**, **Channel**, **Length**, **Freshness**, and **Dates**. Facets are how the user *finds*. |
+| **Tag** | A free-form, multi-value label (`history`, `guitar`, `barca`, `podcast`) carrying topic *and* format. Identity is the **normalised name** — trimmed, internal whitespace collapsed, case-folded — unique per user; the display form the user first typed is preserved for rendering. A Video has zero-or-more Tags. |
+| **Channel** | The source YouTube channel, captured automatically. A browse/filter facet. |
+| **Length** | The Video's duration, captured automatically, stored as integer seconds. A filter facet. |
+| **Playlist** | A hand-built, user-curated, **ordered** collection ("Guitar Course Vol.1"). How the user *curates sequences*, as distinct from Tags/facets which are how he *finds*. Distinct from the YouTube playlists that exist only as source or inbox. |
+| **Freshness / Shelf-life** | A Video is **Evergreen** (never expires) or **Perishable** (has a watch-by window). The app tracks a Perishable's age and flags it once expired. |
+| **Watched** | Derived state, set when the user's **contiguous covered playback** passes the threshold. Shown as a badge; the Video stays in place, and the state is manually togglable. |
+| **Availability** | Whether a Video is still playable on YouTube. **Available** by default; **Unavailable** when YouTube no longer serves it (deleted, private, region-blocked, removed). Metadata survives; playback does not. |
+| **Needs review** | A derived view combining expired Perishables and Unavailable Videos. Like Uncategorized, a state rather than a container. |
+| **Trash** | Soft-deleted Videos, restorable within the retention window. On permanent purge the row is hard-deleted and a **tombstone** (YouTube ID) is written. |
+| **Tombstone** | A lightweight record of a permanently purged YouTube ID, so a deleted Video is never resurrected by a later import from a still-populated `_Inbox`. |
+| **Orphan (pending-clear)** | A Video imported and durably persisted, but not yet removed from `_Inbox` on YouTube. Retried on the next sync, never skipped as a duplicate. |

--- a/_bmad-output/specs/spec-youtube-organizer/phasing.md
+++ b/_bmad-output/specs/spec-youtube-organizer/phasing.md
@@ -1,0 +1,59 @@
+# Phasing — YouTube Organizer
+
+Companion to `SPEC.md`. Scope is **phased, not cut**: phasing sequences capabilities, it deletes
+none. Phase 1 exists to answer one question — *will Alexis actually use this instead of
+doomscrolling?* Everything not needed to answer that is Phase 2.
+
+`WORK-SPLIT.md` decomposes Phase 1 into epics `E1`–`E14` and fixes their dependency order; it is
+the bridge into `bmad-create-epics-and-stories`. This file fixes *what is in which phase*.
+
+## Phase 1 — Prove the premise
+
+The smallest loop that replaces the doomscroll: **capture → organize → find → watch.**
+
+| Capability | Scope in Phase 1 |
+|---|---|
+| CAP-1 | Auth with YouTube **write** scope, plus the read-only degraded mode |
+| CAP-2 | `_Inbox` designation, persisted, changeable, with create-one fallback |
+| CAP-5 | `_Inbox` import → Uncategorized, full local metadata, three-way dedupe |
+| CAP-6 | Crash-safe auto-clear, orphan retry, surfaced failures |
+| CAP-7 | Fast bulk categorization — Tags and discard (Freshness is Phase 2; endpoint schema only) |
+| CAP-9 | Manage Tags — create, apply by delta, rename, remove. **Merge is Phase 2** |
+| CAP-11 | Delete from Library, guarded and recoverable, with Trash and purge-to-tombstone |
+| CAP-12 | Channel and Length as automatic facets |
+| CAP-13 | Browse by combined facets. **The date-range portion is Phase 2** |
+| CAP-14 | Text search over title, description, channel, tags |
+| CAP-15 | Embedded playback + open-in-YouTube |
+| CAP-16 | Contiguous-coverage auto-Watched |
+
+Plus, as cross-cutting Phase 1 work: desktop and mobile web both first-class, and the whole
+Phase-1 surface set in `EXPERIENCE.md § Information Architecture`.
+
+## Phase 2 — Curation depth and convenience
+
+Earned once Phase 1 proves the habit sticks. Deliberately not decomposed into epics.
+
+| Capability | Why it waits |
+|---|---|
+| CAP-3, CAP-4 (migration) | Valuable, but the *weekly loop* is what proves the premise, not the one-time import. Reuses the Phase-1 outbox; **CAP-4's upstream deletion is gated on a recent successful backup** |
+| CAP-10 (hand-built Playlists) | A curation-sequence nicety on top of facet browsing. The schema is anticipated in Phase 1 so this is additive; ordering and reorder are the new work |
+| CAP-17, CAP-18 (Freshness + pruning) | Library-health features that matter more as the Library ages. Adds `freshness` params to the existing browse grammar |
+| CAP-19 (Unavailable detection) | Gateway detection exists from Phase 1; the surface and the review sweep are the new work |
+| CAP-13 date-range filters | Old-save cleanup needs history to be useful. Params are already reserved in the browse grammar |
+| CAP-9 tag merge | Fights drift that only appears after months of tagging. Already assigned to a service operation |
+| CAP-8 (suggestions) | **The triage pressure valve — see the pull-forward trigger below** |
+| Production envelope | Settings split, env-driven secrets, `DEBUG` off, `ALLOWED_HOSTS`, TLS hostname, updated Google redirect URI, a retargeted `deploy.yml`, and scheduled/unattended sync — which needs an always-on host and therefore this whole dimension. **Revisit the moment anything is exposed beyond localhost**; the current dev defaults are unsafe on a real host |
+
+### The CAP-8 pull-forward trigger
+
+CAP-8 is the designed release valve for the triage bound, and it is **not** a wait-and-see item.
+If Phase-1 triage of ~100 videos/week hurts even with bulk tools — i.e. if triage starts costing
+more than the doomscroll it replaced — **pull CAP-8 forward from Phase 2 immediately.** That is
+the PRD's own stated fallback and the reviewers' identified mitigation for counter-metric SM-C2.
+No suggestion mechanism is committed until the valve is actually needed.
+
+## Out of scope in every phase
+
+- Native mobile app — reconsidered only if background playback becomes a hard requirement, which it is not.
+- Background / lock-screen playback in-app — covered by open-in-YouTube.
+- Any multi-user or sharing capability.


### PR DESCRIPTION
## Summary

Distills the planning chain (PRD, DESIGN, EXPERIENCE, ARCHITECTURE-SPINE, WORK-SPLIT) into the canonical SPEC contract for youtube-organizer.

New files under `_bmad-output/specs/spec-youtube-organizer/`:

- **SPEC.md** — the preservation-validated kernel; capability IDs map 1:1 onto the PRD FR ids
- **glossary.md** — the shared vocabulary catalog (PRD section 3)
- **phasing.md** — Phase 1 / Phase 2 / out-of-scope FR matrix plus the FR-8 pull-forward trigger
- **.memlog.md** — BMAD working log (matches the convention of the committed PRD/UX/architecture artifacts)

## Notes

- Precedence recorded in the kernel: ARCHITECTURE-SPINE.md wins over project-context.md and Docs/ on any conflict.
- Docs-only change; no code touched.