### PR TITLE
docs: add pre-commit hook blocking direct commits to main/develop

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Block direct commits to protected branches.
+#
+# All work goes through a feat/story-* or docs/* branch and a PR
+# (see CLAUDE.md and _bmad-output/project-context.md). This hook is the
+# local guardrail for that rule; branch protection on the remote is the
+# authoritative gate.
+#
+# Activate once per clone:  git config core.hooksPath .githooks
+#
+# The four-layer pre-push gate (tsc / lint / test / build / manage.py test)
+# is intentionally NOT here yet — it is owned by Epic 3 Story 3.6 and needs
+# the E1/E2 stack to exist before its commands have real targets.
+
+branch="$(git symbolic-ref --short HEAD 2>/dev/null)"
+
+for protected in main develop; do
+	if [ "$branch" = "$protected" ]; then
+		echo "✗ Direct commits to '$protected' are blocked."
+		echo "  Create a branch (feat/story-* or docs/*) and open a PR."
+		exit 1
+	fi
+done
+
+exit 0


### PR DESCRIPTION
## What

Adds `.githooks/pre-commit` — a local guardrail that blocks direct commits to `main` and `develop`, enforcing the branch-and-PR workflow (CLAUDE.md, `project-context.md`).

Activate once per clone:

```
git config core.hooksPath .githooks
```

## Why now (and why only this hook)

- **Pure git, no build tooling** — works immediately and is independent of the E1–E3 stack rebuild.
- Enforces the rule we currently follow by hand (remembering to branch before committing).
- Stops CLAUDE.md's activation line from referencing a directory that didn't exist.

The **four-layer pre-push gate** (`tsc --noEmit` / lint / `next build` / `jest` / `manage.py test`) is intentionally **not** included — it's owned by **Epic 3 Story 3.6** and needs the E1/E2 stack before its commands have real targets. That story can extend this same `.githooks/` directory.

## Verification

- On `develop` → commit blocked (exit 1) with a clear message.
- On a `docs/*` branch → allowed (exit 0); this PR's own commit is the live proof.